### PR TITLE
fix(@toio/cube): not detected if collisions occur consecutively

### DIFF
--- a/packages/cube/src/characteristics/sensor-characteristic.ts
+++ b/packages/cube/src/characteristics/sensor-characteristic.ts
@@ -103,7 +103,7 @@ export class SensorCharacteristic {
       if (this.prevStatus.isSloped !== parsedData.data.isSloped) {
         this.eventEmitter.emit('sensor:slope', { isSloped: parsedData.data.isSloped })
       }
-      if (this.prevStatus.isCollisionDetected !== parsedData.data.isCollisionDetected) {
+      if (parsedData.data.isCollisionDetected) {
         this.eventEmitter.emit('sensor:collision', { isCollisionDetected: parsedData.data.isCollisionDetected })
       }
       if (this.prevStatus.isDoubleTapped !== parsedData.data.isDoubleTapped) {


### PR DESCRIPTION
`sensor:collision`にてisCollisionDetected=trueのイベントが飛んできた後、再度collisionが発生しているにも関わらず`sensor:collision`が発行されません。
`sensor:slope`など別のイベントによりthis.prevStatusが上書きされると、その次に発生するcollisionのイベントは飛んできています。

`isDoubleTapped` はこちらでは使用していないのですが、同様の問題が発生している可能性があるので確認をお願いします。